### PR TITLE
refs #8: 【再対応】【ホーム】献立プランを変更した際にプラン名が更新されない

### DIFF
--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -20,7 +20,7 @@ export const HomePage = () => {
   // useHomePageカスタムフックから値・関数を取得
   const {
     selectedPlan,
-    selectedPlanStat,
+    // selectedPlanStat,
     menuPlanDtoList,
     menuPlanDtoListStat,
     isMenuPlanComboBoxOpen,
@@ -49,8 +49,9 @@ export const HomePage = () => {
               >
                 <div className="flex justify-between h-full w-full">
                   <button className="h-full w-full">
-                    {selectedPlanStat && !selectedPlanStat.isLoading ? selectedPlan?.menuPlanNm : <LoadingSpinner /> }
-                  </button>
+                    {/* {selectedPlanStat && !selectedPlanStat.isLoading ? selectedPlan?.menuPlanNm : <LoadingSpinner /> } */}
+                    {selectedPlan?.menuPlanNm}
+                  </button> 
                   <div className="flex items-center w-6 cursor-pointer">
                       <i className="fa-solid fa-caret-down" />
                   </div>

--- a/src/providers/HomePageProvider.tsx
+++ b/src/providers/HomePageProvider.tsx
@@ -7,7 +7,7 @@ import { MESSAGE_TYPE, MSG_MISSING_REQUEST } from '@/constants';
 
 export const HomePageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { closeContextMenu, showMessage, setIsOpeningForm, clearMessage } = useApp();
-  const { selectedPlan, selectedPlanStat, selectedPlanMutate } = useSelectedPlan();
+  // const { selectedPlan, selectedPlanStat, selectedPlanMutate } = useSelectedPlan();
   const { menuPlanDtoList, menuPlanDtoListStat } = useMenuPlanList();
   const { toweekMenuPlanDetListDict, toweekMenuPlanDetListDictStat, toweekMenuPlanDetListDictMutate } = useToweekMenuPlanDetListDict();
   const [toweekMenuPlanDetViewListDict, setToweekMenuPlanDetListDictView] = useState<Record<string, ToweekMenuPlanDetView[]>>();
@@ -16,10 +16,26 @@ export const HomePageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [isAddMenuPlanDet, setIsAddMenuPlanDet] = useState<boolean>(false);
 
+  const [selectedPlan, setSelectedPlan] = useState<MenuPlanDto | null>(null);
 
   useEffect(() => {
     if(!toweekMenuPlanDetListDictStat?.isLoading) setToweekMenuPlanDetListDictView(toweekMenuPlanDetListDict);
   }, [toweekMenuPlanDetListDict, toweekMenuPlanDetListDictStat?.isLoading, setToweekMenuPlanDetListDictView]); 
+
+  // 今週の献立を取得
+  useEffect(() => {
+    fetchSelectedPlan();
+  }, []);
+
+  async function fetchSelectedPlan() {
+    try {
+      const response = await apiClient.get("api/home/selectedPlan");
+      const data = await response.data;
+      setSelectedPlan(data);
+    } catch (error: any) {
+      showMessage(error?.response?.data?.detail || error?._messageTimeout || MSG_MISSING_REQUEST, MESSAGE_TYPE.ERROR);
+    }
+  }
 
   const handleMenuPlanComboBoxClick = async (menuPlan: MenuPlanDto) => {
     setIsMenuPlanComboBoxOpen(false);
@@ -37,7 +53,8 @@ export const HomePageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       const data  = response.data;
       console.log(data.message, data);
       // APIレスポンス後に状態を更新（競合状態を回避）
-      selectedPlanMutate(menuPlan);
+      // selectedPlanMutate(menuPlan);
+      setSelectedPlan(menuPlan);
       toweekMenuPlanDetListDictMutate(data.newToweekMenuPlanDetListDict, false);
     } catch (error: any) {
       showMessage(error?.response?.data?.detail || error?._messageTimeout || MSG_MISSING_REQUEST, MESSAGE_TYPE.ERROR);
@@ -84,8 +101,8 @@ export const HomePageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   const contextValue: HomePageContextTypes = {
     selectedPlan,
-    selectedPlanStat,
-    selectedPlanMutate,
+    // selectedPlanStat,
+    // selectedPlanMutate,
     menuPlanDtoList,
     menuPlanDtoListStat,
     toweekMenuPlanDetListDict,

--- a/src/types/contexts/homePageContext.types.ts
+++ b/src/types/contexts/homePageContext.types.ts
@@ -3,8 +3,8 @@ import { MenuPlanDetFormData, MenuPlanDto, ToweekMenuPlanDetView } from "@/types
 
 export interface HomePageContextTypes {
   selectedPlan: MenuPlanDto | undefined;
-  selectedPlanStat: { error: any; isLoading: boolean };
-  selectedPlanMutate: any;
+  // selectedPlanStat: { error: any; isLoading: boolean };
+  // selectedPlanMutate: any;
   menuPlanDtoList: MenuPlanDto[] | undefined;
   menuPlanDtoListStat: { error: any; isLoading: boolean };
   toweekMenuPlanDetListDict: Record<string, ToweekMenuPlanDetView[]> | undefined;


### PR DESCRIPTION
前回対応で改善されなかったため、方法を変えて再対応